### PR TITLE
Fix endless options box height in IE

### DIFF
--- a/src/selectr.css
+++ b/src/selectr.css
@@ -262,7 +262,8 @@
 	position: relative;
 	top: calc(100% + 2px);
 	display: none;
-	overflow: auto;
+	overflow-x: auto;
+	overflow-y: scroll;
 	max-height: 200px;
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
This fixes this annoying bug in IE:
If type in a combination of characters which correspond to none of listed options then dropdown list is expanded throughout the page. 
Does not break anything in other browsers.

Example:

**Before**
![Before](http://i.imgur.com/xu7Yffh.png)

**After**
![After](http://i.imgur.com/JMmaHIG.png)