### PR TITLE
Return Search Results to Caller

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -12,7 +12,7 @@
 	<div id="qunit"></div>
 	<div id="qunit-fixture"></div>
 	<script src="https://code.jquery.com/qunit/qunit-2.1.1.js"></script>
-	<script src="../dist/selectr.min.js"></script>
+	<script src="../src/selectr.js"></script>
 	<script src="index.js"></script>
 </body>
 </html>

--- a/tests/index.js
+++ b/tests/index.js
@@ -157,8 +157,35 @@
             multiSelectr.__done__();
         });
 
+        QUnit.test( "search()", function ( assert ) {
+          var selectr = newSelectr();
+
+          assert.deepEqual(
+            selectr.search("one"),
+            [{value: "value-1", text: "one"}],
+            "matches values by display text"
+          );
+          assert.deepEqual(
+            selectr.search("tw"),
+            [{value: "value-2", text: "two"}],
+            "matches partial values by display text"
+          );
+
+          selectr.input.value = "five";
+          assert.deepEqual(
+            selectr.search(),
+            [{value: "value-5", text: "five"}],
+            "searches from user input"
+          );
+          assert.ok(
+            selectr.tree.querySelector( ".selectr-match" ).textContent.trim() === "five",
+            "live search results are displayed in tree"
+          );
+
+          selectr.__done__();
+        });
+
         // @todo tests for other public API methods:
-        // search
         // add
         // remove
         // removeAll


### PR DESCRIPTION
Fixes https://github.com/Mobius1/Selectr/issues/42
**Based On** https://github.com/Mobius1/Selectr/pull/43

Compiles `search()` results as an array of `{ text, value }` objects and returns them.  This brings the method's behavior in line with its documentation.

`search()` also now distinguishes between being provided a search term, and searching against user input from the text input.  In the former case, no changes are made to the selectr (that is, results are not displayed in the tree).  When searching from user input, results are displayed on the selectr as before.

I've added tests that cover the `search()` method as described in the documentation.

Note, I don't know what tools is used for minification.  The `dist/selectr.min.js` file is **unchanged**.  As a consequence, the test suite is currently running against `src/selectr.js`.  Please let me know how minification should be handled, and I'll be happy to make those changes.