### PR TITLE
Adds nativeKeyboard Module

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1186,7 +1186,7 @@
                 // make sure e.key is a single, printable character
                 // prefer "codePoint" methods; they work with the full range of unicode
                 if (
-                    String[(String.fromCodePoint ? "fromCodePoint" : "fromCharCode")](
+                    String[String.fromCodePoint ? "fromCodePoint" : "fromCharCode"](
                         e.key[String.codePointAt ? "codePointAt" : "charCodeAt"]( 0 )
                     ) === e.key
                 ) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -158,31 +158,32 @@
         });
 
         QUnit.test( "search()", function ( assert ) {
-          var selectr = newSelectr();
+            var selectr = newSelectr();
 
-          assert.deepEqual(
-            selectr.search("one"),
-            [{value: "value-1", text: "one"}],
-            "matches values by display text"
-          );
-          assert.deepEqual(
-            selectr.search("tw"),
-            [{value: "value-2", text: "two"}],
-            "matches partial values by display text"
-          );
+            assert.deepEqual(
+                selectr.search("one"),
+                [{value: "value-1", text: "one"}],
+                "matches values by display text"
+            );
+            assert.deepEqual(
+                selectr.search("tw"),
+                [{value: "value-2", text: "two"}],
+                "matches partial values by display text"
+            );
 
-          selectr.input.value = "five";
-          assert.deepEqual(
-            selectr.search(),
-            [{value: "value-5", text: "five"}],
-            "searches from user input"
-          );
-          assert.ok(
-            selectr.tree.querySelector( ".selectr-match" ).textContent.trim() === "five",
-            "live search results are displayed in tree"
-          );
+            selectr.input.value = "five";
+            assert.deepEqual(
+                selectr.search(),
+                [{value: "value-5", text: "five"}],
+                "searches from user input"
+            );
+            assert.ok( selectr.tree.querySelector( ".selectr-match" ), "tree is displayed" );
+            assert.ok(
+                selectr.tree.querySelector( ".selectr-match" ).textContent.trim() === "five",
+                "live search results are displayed in tree"
+            );
 
-          selectr.__done__();
+            selectr.__done__();
         });
 
         // @todo tests for other public API methods:
@@ -229,6 +230,97 @@
             );
 
             selectr.__done__();
+        });
+
+        QUnit.test( "nativeKeyboard", function ( assert ) {
+            function doKeypress( target, character ) {
+                target.dispatchEvent( new KeyboardEvent( "keydown", { key: character } ) );
+                target.dispatchEvent( new KeyboardEvent( "keyup", { key: character } ) );
+            }
+
+            var singleSelectr = newSelectr( { nativeKeyboard: true } );
+            var multiSelectr = newSelectr( { nativeKeyboard: true, multiple: true } );
+            [singleSelectr, multiSelectr].forEach( function( selectr ) {
+                var subject = (selectr === singleSelectr) ? "select-one" : "select-multi";
+
+                // when focused, [space] should toggle the dropdown.
+                selectr.close();
+                selectr.selected.focus();
+                doKeypress( selectr.selected, " " );
+                assert.ok(
+                    selectr.opened,
+                    subject + " toggles open on [Space] when focused and closed"
+                );
+
+                selectr.open();
+                selectr.selected.focus();
+                doKeypress( selectr.selected, " " );
+                assert.notOk(
+                    selectr.opened,
+                    subject + " toggles closed on [Space] when focused and open"
+                );
+
+                // when closed + focused, [enter], [↓], [↑] should open the dropdown
+                ["Enter", "ArrowDown", "ArrowUp"].forEach( function( key ) {
+                    selectr.close();
+                    document.activeElement.blur();
+                    doKeypress( selectr.selected, key );
+                    assert.notOk(
+                        selectr.opened,
+                        subject + " does not open on [" + key + "] when not focused"
+                    );
+
+                    selectr.close();
+                    selectr.selected.focus();
+                    doKeypress( selectr.selected, key );
+                    assert.ok( selectr.opened, subject + " opens on [" + key + "] when focused" );
+
+                    selectr.open();
+                    selectr.selected.focus();
+                    doKeypress( selectr.selected, key );
+                    assert.ok( selectr.opened, subject + " does not close on [" + key + "]" );
+                });
+
+                // when open, [esc] should close the dropdown
+                selectr.open();
+                doKeypress( selectr.container, "Escape" );
+                assert.notOk( selectr.opened, subject + " closes on [Esc] when open" );
+
+                selectr.close();
+                doKeypress( selectr.container, "Escape" );
+                assert.notOk( selectr.opened, subject + " does not open on [Esc]" );
+
+
+            });
+
+            // when focused and not multiple, typing should select first matching option
+            singleSelectr.selected.focus();
+            doKeypress( singleSelectr.selected, "t" );
+            assert.equal(
+                singleSelectr.getValue(),
+                "value-2",
+                "select-one selects the first matching option when focused and typing"
+            );
+
+            doKeypress( singleSelectr.selected, "h" );
+            assert.equal(
+                singleSelectr.getValue(),
+                "value-3",
+                "select-one builds on existing search on additional typing"
+            );
+
+            // when focused and multiple, typing should open the dropdown and use the search feature
+            multiSelectr.selected.focus();
+            doKeypress( multiSelectr.selected, "e" );
+            assert.ok( multiSelectr.opened, "select-multi opens when focused and typing" );
+            assert.equal(
+                multiSelectr.input.value,
+                "e",
+                "select-multi proxies search feature when focused and typing"
+            );
+
+            singleSelectr.__done__();
+            multiSelectr.__done__();
         });
 
         // @todo tests for other constructor options/settings:

--- a/tests/index.js
+++ b/tests/index.js
@@ -234,8 +234,22 @@
 
         QUnit.test( "nativeKeyboard", function ( assert ) {
             function doKeypress( target, character ) {
-                target.dispatchEvent( new KeyboardEvent( "keydown", { key: character } ) );
-                target.dispatchEvent( new KeyboardEvent( "keyup", { key: character } ) );
+
+                // phantomJS
+                if ( typeof KeyboardEvent !== "function" ) {
+                    ["keydown", "keypress", "keyup"].forEach( function (type) {
+                        var event = document.createEvent( "CustomEvent" );
+                        event.initCustomEvent( type, true, true );
+                        event.key = character;
+                        target.dispatchEvent( event );
+                    });
+                    return;
+                }
+
+                // modern browsers
+                ["keydown", "keypress", "keyup"].forEach( function (type) {
+                    target.dispatchEvent( new KeyboardEvent( type, { key: character } ) );
+                });
             }
 
             var singleSelectr = newSelectr( { nativeKeyboard: true } );


### PR DESCRIPTION
Adds optional native-like keyboard behaviors to Selectr.  This behavior is disabled by default; pass `nativeKeyboard: true` in the constructor options to enable it.
```js
new Selectr( mySelectElement, { nativeKeyboard: true } );
```

- When focused, <kbd>Enter</kbd>, <kbd>   </kbd>, <kbd>↓</kbd>, and <kbd>↑</kbd> will toggle the selectr open
- When focused, <kbd>Esc</kbd> and <kbd>   </kbd> will toggle the selectr closed
- When focused, typing (printable characters) will search display text (from start of string) and select the first matching option on a select-one
- When focused, typing (printable characters) will trigger the `search()` feature on a select-multi

Also:

- Adds QUnit tests for new functionality
  tests run+pass on Chrome and FireFox on Linux; other browsers not yet tested
- Adds `util.startsWith()` for start-of-string matching
- Adds `anchor` argument to `search()`; pass `true` for start-of-string matching
- `search()` no longer ignores one-character search strings