### PR TITLE
nativeKeyboard Should Listen to "keydown"

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1162,7 +1162,7 @@
             var typing = '';
             var typingTimeout = null;
 
-            this.selected.addEventListener("keyup", function (e) {
+            this.selected.addEventListener("keydown", function (e) {
                 // Do nothing if disabled, not focused, or modifier keys are pressed
                 if (
                     that.disabled ||


### PR DESCRIPTION
Fixes unexpected behavior (e.g., re-opening dropdown after pressing <kbd>Enter</kbd>) when `searchable` is false.  

Unfortunately, I've been unable to reproduce this problem (or the fix) in automated tests.  For manual testing:

- make a Selectr with `{ nativeKeyboard: true, searchable: false }`
- click to open the dropdown
- navigate with <kbd>↓</kbd> and/or <kbd>↑</kbd>
- select an option by pressing <kbd>Enter</kbd>

currently, the dropdown closes and then immediately re-opens.
changing `keyup` to `keydown` produces the expected (correct) behavior.