### PR TITLE
Set tabindex to 0 or "un-ordered"

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -437,7 +437,7 @@
         this.selected = util.createElement("div", {
             class: "selectr-selected",
             disabled: this.disabled,
-            tabIndex: 1, // enable tabIndex (#9)
+            tabIndex: 0,
             "aria-expanded": false
         });
 


### PR DESCRIPTION
Setting `tabindex` to 1 (current behavior) makes the selectr element the first element that is tabbed to. This is rarely the desired case.

Setting `tabindex` to 0 (proposed behavior) tells the browser to enable tabbing to the element without specifying the order.