### PR TITLE
Minor Fixes

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1178,6 +1178,7 @@
                     (! that.opened && ["Enter", "ArrowUp", "ArrowDown"].indexOf(e.key) > -1)
                 ) {
                     that.toggle();
+                    e.preventDefault();
                     e.stopPropagation();
                     return;
                 }
@@ -1209,6 +1210,7 @@
                         }
                         setTimeout(function () { typing = ''; }, 1000);
                     }
+                    e.preventDefault();
                     e.stopPropagation();
                     return;
                 }

--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1205,7 +1205,7 @@
                         }
                         typing += e.key;
                         var found = that.search( typing, true );
-                        if ( found.length ) {
+                        if ( found && found.length ) {
                             that.clear();
                             that.setValue( found[0].value );
                         }

--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1155,6 +1155,7 @@
                 that.toggle();
             }
 
+            e.stopPropagation();
             e.preventDefault();
         });
 
@@ -1266,6 +1267,9 @@
                     }
                 }
             }
+
+            e.preventDefault();
+            e.stopPropagation();
         });
 
         // Mouseover list items

--- a/tests/index.js
+++ b/tests/index.js
@@ -63,6 +63,9 @@
 
             assert.equal( typeof selectr, "object", "can create new instance" );
             assert.equal( selectr.el, s, "instance has reference to <select> element" );
+
+            selectr.destroy();
+            document.body.removeChild(s);
         });
 
         QUnit.test( "api methods", function( assert ) {


### PR DESCRIPTION
- type-to-search on multi-selects was resulting in doubling the first search character due to overlapping event listeners
- `this.navigating` should be cleared on close; was disabling search-to-type after selecting an item via the keyboard
- `search()` should only modify the DOM for "live" searches; was resulting in mixed-up display order for options
- on `open()`, highlight the first selected option if any; first option otherwise
- other minor fixes