### PR TITLE
Two minor changes

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -8,7 +8,7 @@
     var plugin = "Selectr";
 
     if (typeof define === "function" && define.amd) {
-        define([], factory(plugin));
+        define([], factory);
     } else if (typeof exports === "object") {
         module.exports = factory(plugin);
     } else {

--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1092,13 +1092,11 @@
                 }
             });
 
-            if (this.config.nativeDropdown || this.mobileDevice) {
-                this.container.addEventListener("click", function(e) {
-                    if (e.target === that.el) {
-                        that.toggle();
-                    }
-                });
-            }
+            this.container.addEventListener("click", function(e) {
+                if (e.target === that.el) {
+                    that.toggle();
+                }
+            });
 
             var getChangedOptions = function(last, current) {
                 var added=[], removed=last.slice(0);


### PR DESCRIPTION
- Deleted an if-statement that wasn't needed (as the statement was nested inside an identical "if" at line 2278)
- "Fixed" the AMD import.  I think I did this correctly, but you may disagree.  The `define` function is supposed to have as its second argument a function that will be called, passing in the module's dependencies.  I guess another way to do this would be `define([], function() { return factory(plugin); });`, if it is necessary to pass that `plugin` variable in still.
