### PR TITLE
Bugfix for missing index on search with optgroups

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1923,7 +1923,7 @@
                 } else {
                     // Highlight top result (@binary-koan #26)
                     var prevEl = this.items[this.navIndex];
-                    var firstEl = f.firstElementChild;
+                    var firstEl = f.querySelector(".selectr-option:not(.excluded)");
 
                     util.removeClass( prevEl, "active" );
                     this.navIndex = firstEl.idx;


### PR DESCRIPTION
This fixes a bug, where no items were selected during live search if you use optgroups. This can also be verified on the original demo page.
The original approach to get the first child from live search dropdown in Selectr.prototype.search on line 1926 was to use firstElementChild.
But this returns the pseudo optgroup li item and not a real result. This can be fixed by using querySelector(".selectr-option:not(.excluded)").