### PR TITLE
Update selectr.js

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1683,7 +1683,7 @@
         }
 
         util.each(this.options, function(i, option) {
-            if (isArray && util.includes(value, option.value.toString()) || option.value === value) {
+            if (isArray && (value.indexOf(option.value) > -1) || option.value === value) {
                 this.change(option.idx);
             }
         }, this);
@@ -2309,3 +2309,4 @@
 
     return Selectr;
 }));
+


### PR DESCRIPTION
Previously checked when an existing option matched any substring of the setValue option. This meant doing setValue("Book Review 2016") would match "Book" "Review", "2016" "Book Review" and "Book Review 2016". Now it treats each tag as a whole unit and will only match "Book Review 2016".