### PR TITLE
Checking for items before default selecting first item (bugfix)

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1514,7 +1514,7 @@
         if (this.config.data) {
 
 
-            if (!this.el.multiple && this.config.defaultSelected && this.el.selectedIndex < 0) {
+            if (!this.el.multiple && this.config.defaultSelected && this.el.selectedIndex < 0 && this.config.data.length > 0) {
                 this.select(0);
             }
 
@@ -1618,7 +1618,7 @@
             this.selectedIndexes.push(index);
 
             addTag.call(this, item);
-        } else {
+        } else {            
             var data = this.data ? this.data[index] : option;
             this.label.innerHTML = this.customSelected ? this.config.renderSelection(data) : option.textContent;
 


### PR DESCRIPTION
Added check for data length before default selecting first element.

Otherwise an exception would occure in this.select(0); that follows to not draw the element in html.