### PR TITLE
Undo Breaking Changes (from 37bf850)

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1222,34 +1222,19 @@
 
         }
 
-        // Keyboard Support
-        this.container.addEventListener("keydown", function(e) {
-            if (e.key === "Escape") {
-              that.close();
-            }
-
-            if (e.key === "Enter" && that.selected === document.activeElement) {
-                if (that.el.form && typeof that.el.form.submit !== 'undefined') that.el.form.submit();
-            }
-
-            if ((e.key === " " || e.key === "ArrowUp" || e.key === "ArrowDown") &&
-              that.selected === document.activeElement) {
-                if (e.key === " ") {
-                  e.preventDefault();
-                }
-
-                setTimeout(function() {
-                    that[e.key === " " ? 'toggle' : 'open']();
-                }, 200);
-
-                if (that.config.nativeDropdown) {
-                    // Focus on the native multiselect
+        // Open the dropdown with Enter key if focused
+        if ( this.config.nativeDropdown ) {
+            this.container.addEventListener("keydown", function(e) {
+                if (e.key === "Enter" && that.selected === document.activeElement) {
+                    // show native dropdown
+                    that.toggle();
+                    // focus on it
                     setTimeout(function() {
                         that.el.focus();
                     }, 200);
                 }
-            }
-        });
+            });
+        }
 
         // Non-native dropdown
         this.selected.addEventListener("click", function(e) {
@@ -2182,7 +2167,6 @@
 
         util.truncate(this.tree);
         clearSearch.call(this);
-        this.selected.focus();
     };
 
 


### PR DESCRIPTION
re: https://github.com/Mobius1/Selectr/pull/51

> After tabbing to a selectr element, pressing the typical keyboard activation keys (space, up/down) wouldn't open the selectr container. Pressing Enter wouldn't submit the form (or do anything).

> After dismissing the dialog (e.g. via pressing enter), the tab focus was lost thus starting you back over at the top of the document (making using keyboard only navigation painful).

These behaviors (except form submission on <kbd>Enter</kbd>; see below) already exist in Selectr.
To enable them, you should set `config.nativeKeyboard = true`.
Personally, I would be in favor of enabling them by default, which might also prevent confusion like this in the future.

Unfortunately, these changes did not simply duplicate existing behavior, but caused some problems as well:

- The event listeners that were added/modified were previously only set up when the `nativeDropdown` option was enabled, but are now set up _unconditionally_.
  This causes conflicts and duplicated events when `nativeKeyboard` is enabled.

- Making <kbd>Enter</kbd> submit the form when a `<select>` element is focused is **unexpected** and often undesired.
  When a select box is focused, normal browser behavior when pressing <kbd>Enter</kbd> is to open the select box (or select an option if already open).
  Implicit form submission should only happen when a form `<input>` is in focus.
  See the whatwg standard for more info: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission

- returning focus to the select container when closing it is also (imo) unexpected, but, more importantly, cause focus to become "stuck" on the selectr in some cases.
  For example, if an `onBlur` event listener calls `close()` on the select, then focus will immediately return to it, and the form (potentially, the entire page) becomes unusable.
  When using `nativeKeyboard`, closing the select via <kbd>Enter</kbd> or <kbd>Escape</kbd> does not cause focus to be lost.

Suggestions for future changes:

If there is some standard keyboard behavior that is missing from Selectr, if should be added behind the `nativeKeyboard` config option.

If there is some nonstandard keyboard behavior that is deemed desirable, it should be added behind its own config option, or, if added globally, should be disabled when the `nativeKeyboard` option is enabled.

TL;DR:
======
Set `config.nativeKeyboard = true` instead.