### PR TITLE
Prevent deleting optgroups on open() in mobile viewport

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -2095,7 +2095,7 @@
         if (this.mobileDevice || this.config.nativeDropdown) {
             util.addClass(this.container, "native-open");
 
-            if (this.config.data) {
+            if (this.config.data && this.el.options.length === 0) {
                 // Dump the options into the select
                 // otherwise the native dropdown will be empty
                 util.each(this.options, function(i, option) {


### PR DESCRIPTION
This PR should fix https://github.com/Mobius1/Selectr/issues/91
But I'm not sure, if the code around is still relevant. I tried some testcases with `config.data` and native options in select as initial markup and all seems to work.

## Question
```
if (this.config.data) {  
	// Dump the options into the select
	// otherwise the native dropdown will be empty
	util.each(this.options, function(i, option) {
		this.el.add(option);
	}, this);
}
```
- What's the role of `this.config.data` here?
- `data` is already assigned to selectr and native select on `build()` call if I `console.log(this.el)` - so why adding the options again?
