### PR TITLE
feat: ignoring spaces and hyphens upon search

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/Mobius1/Selectr#readme",
   "devDependencies": {
-    "grunt": "^1.0.1",
-    "grunt-contrib-qunit": "^1.3.0" ,
-    "qunit": "~0.5.15",
+    "grunt": "^1.0.4",
     "grunt-contrib-jshint": "~0.4.3",
+    "grunt-contrib-qunit": "^1.3.0",
+    "qunit": "~0.5.15",
     "qunitjs": "~1.11.0"
   }
 }

--- a/src/selectr.js
+++ b/src/selectr.js
@@ -2015,7 +2015,7 @@
 
             util.each( this.options, function ( i, option ) {
                 var item = this.items[option.idx];
-                var matches = compare( option.textContent.trim().toLowerCase(), string );
+                var matches = compare( option.textContent.trim().toLowerCase().replace(/-|\s/g,""), string.replace(/-|\s/g,"") );
 
                 if ( matches && !option.disabled ) {
                     results.push( { text: option.textContent, value: option.value } );


### PR DESCRIPTION
This is an attempt to prevent the search results from being sensitive to hyphens or internal spaces.

Note that I did not minimise into selectr.min.js, but only changed the line 2018 of selectr.js.

