### PR TITLE
Change .selectr-selected item alignment

### DIFF
--- a/src/selectr.css
+++ b/src/selectr.css
@@ -31,6 +31,9 @@
 	border: 1px solid #999;
 	border-radius: 3px;
 	background-color: #fff;
+	display: flex;
+    	flex-direction: row;
+    	align-items: center;
 }
 
 .selectr-selected::before {


### PR DESCRIPTION
If anyone changes the font size then they will have vertical elements centered.
Before:
```
===============
(item) (item) (item)


===============
```

After:
```
===============

(item) (item) (item)

==============
```

OR

Before:
```
===============
(item) (item)
(item) (item)


===============
```

After:
```
===============

(item) (item)
(item) (item)

===============
```