### PR TITLE
Fix back list after delete search word with button

### DIFF
--- a/src/selectr.js
+++ b/src/selectr.js
@@ -1407,6 +1407,7 @@
                 if (!that.tree.childElementCount) {
                     render.call(that);
                 }
+                that.search();
             });
         }
 


### PR DESCRIPTION
After clearing the search box, the list of items does not refresh. I added this line and the deletion started restoring the original list.